### PR TITLE
More Suspend

### DIFF
--- a/RFC.md
+++ b/RFC.md
@@ -48,9 +48,9 @@ abstract class Source(context: ExtensionContext): EISource, ExtensionContext by 
 
     abstract val language: String
 
-    abstract fun getListings(): List<Listing>
-    abstract fun getFilterList(listing: Listing): FilterList
-    abstract fun getSearchFilterList(): FilterList
+    abstract suspend fun getListings(): List<Listing>
+    abstract suspend fun getFilterList(listing: Listing): FilterList
+    abstract suspend fun getSearchFilterList(): FilterList
 
     abstract suspend fun getMangaList(
         listing: Listing,
@@ -79,12 +79,12 @@ abstract class HttpSource(context: ExtensionContext): Source(context) {
 
     val needPcUserAgent: Boolean get() = true
 
-    abstract fun getMangaUrl(manga: Manga): String
-    abstract fun getChapterUrl(chapter: Chapter): String
+    abstract suspend fun getMangaUrl(manga: Manga): String
+    abstract suspend fun getChapterUrl(chapter: Chapter): String
 
-    abstract fun getImageRequest(url: String): HttpRequest
+    abstract suspend fun getImageRequest(url: String): HttpRequest
 
-    abstract fun getCoverRequest(manga: Manga): HttpRequest
+    abstract suspend fun getCoverRequest(manga: Manga): HttpRequest
 }
 ```
 ## MangaPagingSource


### PR DESCRIPTION
Many things regarding listings and filter lists can need network requests, such if we want to fetch tags from the source, or create listings based on what listings the source has.

For getting urls, this can also require network requests since we may need to remotely get a url based on a api call.