### PR TITLE
Chapter Branch

### DIFF
--- a/RFC.md
+++ b/RFC.md
@@ -188,6 +188,7 @@ class Chapter(
     val scanlators: List<String> = emptyList(),
     val lockedStatus: ChapterLockState = ChapterLockState.NONE,
     val internalData: String = "",
+    val branch: String? = null,
 )
 
 enum class ChapterLockState(val isLocked: Boolean, val disablePageFetch: Boolean) {


### PR DESCRIPTION
basically this allows the app to differentiate between multiple chapter lists/types. e.g, multiple different languages or volume/chapter release or coloured/non-coloured version etc.

App will show a drop down above chapter list and allow user to select the branch they want. Only one branch can be enabled at a time. 
This would allow merging language based factory sources into one, which provides all language chapters in a single entry, separated by the branch.

~totally not stolen idea from kotatsu~

Another approach can be to make `val chapters: List<Pair<String, List<Chapter>>>` in the `Manga` model, but that seems dirty...