### PR TITLE
Add field for alternative covers

### DIFF
--- a/RFC.md
+++ b/RFC.md
@@ -75,8 +75,6 @@ abstract class Source(context: ExtensionContext): EISource, ExtensionContext by 
 
     abstract suspend fun getMangaUpdate(manga: Manga, needDetails: Boolean, needChapters: Boolean): Manga
     
-    abstract suspend fun getAlternativeCovers(manga: Manga): List<String>
-
     abstract suspend fun getPageList(chapter: Chapter): List<Page>
 
     suspend fun getPage(page: PageUrl): PageComplete = throw UnsupportedOperationException()
@@ -165,7 +163,7 @@ class Manga(
     val genres: List<String> = emptyList(),
     val status: MangaStatus = MangaStatus.Unknown,
     val cover: String? = null,
-    val hasAltCovers: Boolean = false,
+    val altCovers: List<String> = emptyList(),
     val rating: Float = -1f, 
     val updateStrategy: UpdateStrategy = UpdateStrategy.AlwaysUpdate,
     val initialized: Boolean = false,

--- a/RFC.md
+++ b/RFC.md
@@ -74,6 +74,8 @@ abstract class Source(context: ExtensionContext): EISource, ExtensionContext by 
     ): MangaPagingSource
 
     abstract suspend fun getMangaUpdate(manga: Manga, needDetails: Boolean, needChapters: Boolean): Manga
+    
+    abstract suspend fun getAlternativeCovers(manga: Manga): List<String>
 
     abstract suspend fun getPageList(chapter: Chapter): List<Page>
 
@@ -163,6 +165,7 @@ class Manga(
     val genres: List<String> = emptyList(),
     val status: MangaStatus = MangaStatus.Unknown,
     val cover: String? = null,
+    val hasAltCovers: Boolean = false,
     val rating: Float = -1f, 
     val updateStrategy: UpdateStrategy = UpdateStrategy.AlwaysUpdate,
     val initialized: Boolean = false,


### PR DESCRIPTION
If a site has multiple covers, it would be nice to be able to easily switch between them from the app. Understandably a pretty niche feature for not a lot of sites, but it shouldn't bloat the extensions for the sites that doesn't support it.